### PR TITLE
Consider also tilde and colon as a heading markers

### DIFF
--- a/rst2ctags.py
+++ b/rst2ctags.py
@@ -95,7 +95,7 @@ class Section(object):
         return '<Section %s %d %d>' % (self.name, self.level, self.lineNumber)
 
 
-headingRe = re.compile(r'^[-=^"#*.]+$')
+headingRe = re.compile(r'^[-=~:^"#*.]+$')
 subjectRe = re.compile(r'^[^\s]+.*$')
 
 def findSections(filename, lines):


### PR DESCRIPTION
Add `~` and `:` to the regex that finds headings.
