### PR TITLE
make it python2 explicitly

### DIFF
--- a/rst2ctags.py
+++ b/rst2ctags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013 John Szakmeister <john@szakmeister.net>
 # All rights reserved.


### PR DESCRIPTION
Some distributions redirect python to python3 by default, it will cause rst2ctags fail silently. But it can be solved by declaring it python2 instead of python