### PR TITLE
Headers must be homogenous

### DIFF
--- a/rst2ctags.py
+++ b/rst2ctags.py
@@ -99,7 +99,7 @@ class Section(object):
         return '<Section %s %d %d>' % (self.name, self.level, self.lineNumber)
 
 
-headingRe = re.compile(r'''^[-=~:^"#*._+`']+$''')
+headingRe = re.compile(r'''^([-=~:^"#*._+`'])\1+$''')
 subjectRe = re.compile(r'^[^\s]+.*$')
 
 def findSections(filename, lines):


### PR DESCRIPTION
The old way, table row separators were being identified as headers, because they were a mix of + and -.  This should be a header: "------", or "+++++++", but this should not: "+-----+------+".